### PR TITLE
Fix validator so that margins have to be string instead of integer

### DIFF
--- a/HttpClient/service.json
+++ b/HttpClient/service.json
@@ -87,30 +87,30 @@
                 "margin_top":{
                     "required": false,
                     "location": "postField",
-                    "type": "integer",
-                    "default": 10,
-                    "description": "Top margin of PDF (in mm)"
+                    "type": "string",
+                    "default": "10mm",
+                    "description": "Top margin of PDF"
                 },
                 "margin_bottom":{
                     "required": false,
                     "location": "postField",
-                    "type": "integer",
-                    "default": 10,
-                    "description": "Bottom margin of PDF (in mm)"
+                    "type": "string",
+                    "default": "10mm",
+                    "description": "Bottom margin of PDF"
                 },
                 "margin_right":{
                     "required": false,
                     "location": "postField",
-                    "type": "integer",
-                    "default": 10,
-                    "description": "Right margin of PDF (in mm)"
+                    "type": "string",
+                    "default": "10mm",
+                    "description": "Right margin of PDF"
                 },
                 "margin_left":{
                     "required": false,
                     "location": "postField",
-                    "type": "integer",
-                    "default": 10,
-                    "description": "Left margin of PDF (in mm)"
+                    "type": "string",
+                    "default": "10mm",
+                    "description": "Left margin of PDF"
                 },
                 "background":{
                     "required": false,
@@ -349,30 +349,30 @@
                 "margin_top":{
                     "required": false,
                     "location": "postField",
-                    "type": "integer",
-                    "default": 10,
-                    "description": "Top margin of PDF (in mm)"
+                    "type": "string",
+                    "default": "10mm",
+                    "description": "Top margin of PDF"
                 },
                 "margin_bottom":{
                     "required": false,
                     "location": "postField",
-                    "type": "integer",
-                    "default": 10,
-                    "description": "Bottom margin of PDF (in mm)"
+                    "type": "string",
+                    "default": "10mm",
+                    "description": "Bottom margin of PDF"
                 },
                 "margin_right":{
                     "required": false,
                     "location": "postField",
-                    "type": "integer",
-                    "default": 10,
-                    "description": "Right margin of PDF (in mm)"
+                    "type": "string",
+                    "default": "10mm",
+                    "description": "Right margin of PDF"
                 },
                 "margin_left":{
                     "required": false,
                     "location": "postField",
-                    "type": "integer",
-                    "default": 10,
-                    "description": "Left margin of PDF (in mm)"
+                    "type": "string",
+                    "default": "10mm",
+                    "description": "Left margin of PDF"
                 },
                 "background":{
                     "required": false,
@@ -611,30 +611,30 @@
                 "margin_top":{
                     "required": false,
                     "location": "postField",
-                    "type": "integer",
-                    "default": 10,
-                    "description": "Top margin of PDF (in mm)"
+                    "type": "string",
+                    "default": "10mm",
+                    "description": "Top margin of PDF"
                 },
                 "margin_bottom":{
                     "required": false,
                     "location": "postField",
-                    "type": "integer",
-                    "default": 10,
-                    "description": "Bottom margin of PDF (in mm)"
+                    "type": "string",
+                    "default": "10mm",
+                    "description": "Bottom margin of PDF"
                 },
                 "margin_right":{
                     "required": false,
                     "location": "postField",
-                    "type": "integer",
-                    "default": 10,
-                    "description": "Right margin of PDF (in mm)"
+                    "type": "string",
+                    "default": "10mm",
+                    "description": "Right margin of PDF"
                 },
                 "margin_left":{
                     "required": false,
                     "location": "postField",
-                    "type": "integer",
-                    "default": 10,
-                    "description": "Left margin of PDF (in mm)"
+                    "type": "string",
+                    "default": "10mm",
+                    "description": "Left margin of PDF"
                 },
                 "background":{
                     "required": false,

--- a/Validator/HtmlPdfApiValidator.php
+++ b/Validator/HtmlPdfApiValidator.php
@@ -64,17 +64,17 @@ class HtmlPdfApiValidator implements ValidatorInterface {
                 array("landscape", "portrait"))))
             throw new InvalidParameterException('Orientation must be set to either "landscape" or "portrait"');
 
-        if (!empty($params['margin_top']) && !is_int($params['margin_top']))
-            throw new InvalidParameterException('Margin top must be an integer.');
+        if (!empty($params['margin_top']) && !is_string($params['margin_top']))
+            throw new InvalidParameterException('Margin top must be a string.');
 
-        if (!empty($params['margin_bottom']) && !is_int($params['margin_bottom']))
-            throw new InvalidParameterException('Margin top must be an integer.');
+        if (!empty($params['margin_bottom']) && !is_string($params['margin_bottom']))
+            throw new InvalidParameterException('Margin bottom must be a string.');
 
-        if (!empty($params['margin_left']) && !is_int($params['margin_left']))
-            throw new InvalidParameterException('Margin top must be an integer.');
+        if (!empty($params['margin_left']) && !is_string($params['margin_left']))
+            throw new InvalidParameterException('Margin left must be a string.');
 
-        if (!empty($params['margin_right']) && !is_int($params['margin_right']))
-            throw new InvalidParameterException('Margin top must be an integer.');
+        if (!empty($params['margin_right']) && !is_string($params['margin_right']))
+            throw new InvalidParameterException('Margin right must be a string.');
 
         if (!empty($params['background']) && (!is_int($params['background']) || !in_array($params['background'], array(
                     0, 1 ) )))
@@ -153,7 +153,7 @@ class HtmlPdfApiValidator implements ValidatorInterface {
                 'Use print media must be either 0 or 1 (alternative: use bool values');
 
         if (!empty($params['zoom']) && !is_numeric($params['zoom']))
-            throw new InvalidParameterException('Zoom must be an integer.');
+            throw new InvalidParameterException('Zoom must be a float (eg. 1.2).');
 
         if (!empty($params['viewport_size']) &&
             (!is_string($params['viewport_size'] || preg_match("^\\d+x\\d+$", $params['viewport_size']))))
@@ -250,4 +250,4 @@ class HtmlPdfApiValidator implements ValidatorInterface {
 
         return $params;
     }
-} 
+}


### PR DESCRIPTION
According to HtmlPdfApi documentation, margins have to be string (eg. "10mm"), while the validator is checking if it's an integer (probably it was an integer before). Also, Guzzle JSON service description is expecting integer as well. Due to that, it is not possible to use margins, because the validator will fail if string is provided, and the API will return an error if integer is provided.