### PR TITLE
Change parameter name and corresponding Guzzle operation name

### DIFF
--- a/HttpClient/Guzzle.php
+++ b/HttpClient/Guzzle.php
@@ -55,8 +55,8 @@ class Guzzle extends Client implements HttpClientInterface {
             if (!empty($params['html'])){
                 $commandName = 'GenerateFromHTML';
             }
-            else if (!empty($params['pdf'])){
-                $commandName = 'GenerateFromPDF';
+            else if (!empty($params['url'])){
+                $commandName = 'GenerateFromURL';
             }
             else if (!empty($params['file'])&& $url=='pdf'){
                 $commandName = 'GenerateFromFile';


### PR DESCRIPTION
HtmlPdfApi supports PDF creation from provided HTML, file or URL. The library expects 'html', 'file' or 'pdf' parameters (which should be 'file'), and also calls non-existing ''GenerateFromPDF' Guzzle operation (should be 'GenerateFromURL'. Probably a typo or a change in API.